### PR TITLE
bump default gke version to 1.10.6-gke.2

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -14,5 +14,5 @@ variable "initial_node_count" {
 
 variable "gke_version" {
   description = "gke master/node version"
-  default     = "1.10.4-gke.2"
+  default     = "1.10.6-gke.2"
 }


### PR DESCRIPTION
gke no longer supports 1.10.4-gke.2