### PR TITLE
fix strange gke node_pool idempotency issue

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -86,6 +86,7 @@ resource "google_container_cluster" "gke_std" {
   lifecycle {
     ignore_changes = [
       "initial_node_count",
+      "node_pool.0.node_config.0.metadata",
     ]
   }
 }


### PR DESCRIPTION
The gke cluster mysteriously started being force recreated on subsequent applys:
```
-/+ module.gke.google_container_cluster.gke_std (new resource required)
      ...
      node_pool.0.node_config.0.metadata.%:                                         "1" => "0" (forces new resource)
      node_pool.0.node_config.0.metadata.disable-legacy-endpoints:                  "true" => "" (forces new resource)
```