### PR TITLE
do not pin aliased kubernetes provier version

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -3,8 +3,7 @@ locals {
 }
 
 provider "kubernetes" {
-  version = "1.6.2"
-  alias   = "gke_std"
+  alias = "gke_std"
 
   load_config_file = true
   config_path      = "${local.kubeconfig_filename}"


### PR DESCRIPTION
To allow the caller to control the provider version.