### PR TITLE
do not write out/test kubeconfig

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,6 @@ provider "kubernetes" {
 | host | kubernetes cluster api endpoint host |
 | id |  |
 | kubeconfig | kubeconfig format string |
-| kubeconfig\_filename | path to output kubeconfig format file |
 | token | kubernetes cluster access token |
 
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->

--- a/kubeconfig.tf
+++ b/kubeconfig.tf
@@ -8,9 +8,3 @@ data "template_file" "kubeconfig" {
     gcloud_cmd          = "${var.gcloud_cmd}"
   }
 }
-
-# there does not seem to be a sane way to ignore changes in the file on disk
-resource "local_file" "kubeconfig" {
-  content  = "${data.template_file.kubeconfig.rendered}"
-  filename = "${local.kubeconfig_filename}"
-}

--- a/main.tf
+++ b/main.tf
@@ -13,31 +13,6 @@ provider "kubernetes" {
   token                  = "${data.google_client_config.default.access_token}"
 }
 
-resource "null_resource" "k8s_ready" {
-  provisioner "local-exec" {
-    working_dir = "${path.module}"
-
-    command = <<EOS
-for i in `seq 1 10`; do \
-kubectl --kubeconfig ${null_resource.k8s_ready.triggers.config_path} get ns && break || \
-sleep 10; \
-done; \
-EOS
-
-    interpreter = ["/bin/sh", "-c"]
-  }
-
-  triggers {
-    config_path = "${local_file.kubeconfig.filename}"
-    kubeconfig  = "${local_file.kubeconfig.content}"
-  }
-
-  depends_on = [
-    "local_file.kubeconfig",
-    "google_container_cluster.gke_std",
-  ]
-}
-
 data "google_container_engine_versions" "gke_std" {}
 
 resource "google_container_cluster" "gke_std" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -15,11 +15,6 @@ output "cluster_ca_certificate" {
   value     = "${google_container_cluster.gke_std.master_auth.0.cluster_ca_certificate}"
 }
 
-output "kubeconfig_filename" {
-  description = "path to output kubeconfig format file"
-  value       = "${pathexpand(local_file.kubeconfig.*.filename[0])}"
-}
-
 output "kubeconfig" {
   # not actually sensitive... just a lot of output
   sensitive   = true

--- a/pd-ssd-storageclass.tf
+++ b/pd-ssd-storageclass.tf
@@ -18,6 +18,6 @@ resource "kubernetes_storage_class" "pd_ssd" {
 
   # needed when the gke cluster is recreated
   depends_on = [
-    "null_resource.k8s_ready",
+    "google_container_cluster.gke_std",
   ]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -21,7 +21,3 @@ variable "gcloud_cmd" {
   description = "Whether to write a Kubectl config file containing the cluster configuration. Saved to `kubeconfig_output_path`."
   default     = "gcloud"
 }
-
-locals {
-  kubeconfig_filename = "${path.module}/kubeconfig_${var.name}"
-}


### PR DESCRIPTION
As the gcp auth provider modifies the kubeconfig file, causing the file
to be re-written on every subsequent tf run.